### PR TITLE
FIX: reset and refill tokens in distributed mode

### DIFF
--- a/src/native/redis_storage.hpp
+++ b/src/native/redis_storage.hpp
@@ -80,4 +80,19 @@ public:
 
         g_redisLoader.freeReplyObject(reply);
     }
+    
+    void reset(const std::string& key, int64_t maxTokens) override {
+        std::string fullKey = prefix + key;
+        
+        // SET key maxTokens
+        redisReply* reply = (redisReply*)g_redisLoader.redisCommand(redis,
+            "SET %s %lld",
+            fullKey.c_str(), maxTokens);
+
+        if (!reply) {
+            throw std::runtime_error("Redis command failed");
+        }
+
+        g_redisLoader.freeReplyObject(reply);
+    }
 }; 


### PR DESCRIPTION
Update NATS and Redis storage implementations to include reset functionality and modify token handling

- Changed TTL in NATS storage from 1 hour to 24 hours.
- Updated token handling in NATS storage to use 'tokens' instead of 'maxTokens'.
- Added reset method in both NATS and Redis storage to set the value to maxTokens.
- Enhanced rate limiter to call reset on distributed storage when necessary.